### PR TITLE
Update openvino to version 2022.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "tqdm>=4.30.0",
     "rapidfuzz>=1.6.0",
     "huggingface-hub>=0.4.0",
-    "openvino==2022.2.0",
+    "openvino==2022.3.0",
     "onnxruntime-gpu>=1.12.1; sys_platform == 'linux'",
     "onnxruntime>=1.12.1; sys_platform == 'darwin'",
 ]


### PR DESCRIPTION
Version 2022.3.0 was released on 2022-12-21, and is an LTS release (https://github.com/openvinotoolkit/openvino/releases/tag/2022.3.0)