### PR TITLE
Adjust import path for rapidfuzz

### DIFF
--- a/doctr/models/recognition/utils.py
+++ b/doctr/models/recognition/utils.py
@@ -5,7 +5,7 @@
 
 from typing import List
 
-from rapidfuzz.string_metric import levenshtein
+from rapidfuzz.distance.Levenshtein import distance as levenshtein
 
 __all__ = ["merge_strings", "merge_multi_strings"]
 

--- a/doctr/models/recognition/utils.py
+++ b/doctr/models/recognition/utils.py
@@ -5,7 +5,9 @@
 
 from typing import List
 
+# https://github.com/maxbachmann/RapidFuzz/blob/0fd8371665c713f1302de58ad2755e68df913688/src/rapidfuzz/string_metric.py#L80
 from rapidfuzz.distance.Levenshtein import distance as levenshtein
+
 
 __all__ = ["merge_strings", "merge_multi_strings"]
 


### PR DESCRIPTION
Copied over[ from slack](https://h2oai.slack.com/archives/C04J5J70822/p1681759842902949?thread_ts=1681748226.265739&cid=C04J5J70822), by @st-pasha 
>Rapidfuzz has removed .string_metric in version 3.0.0 (https://github.dev/maxbachmann/RapidFuzz/blob/c8be9093320bedcd1d75a816b6a554233074db78/CHANGELOG.rst#L19-L20). Doctr's code needs to be adjusted to the new import path.

According to[ this,](https://github.com/maxbachmann/RapidFuzz/blob/0fd8371665c713f1302de58ad2755e68df913688/src/rapidfuzz/string_metric.py#L80) 
Changed `from rapidfuzz.string_metric import levenshtein` to `from rapidfuzz.distance.Levenshtein import distance`