### PR TITLE
Unify GPU detection and make it aware of arm m1 GPUs

### DIFF
--- a/doctr/models/recognition/predictor/pytorch.py
+++ b/doctr/models/recognition/predictor/pytorch.py
@@ -10,6 +10,7 @@ import torch
 from torch import nn
 import os
 from doctr.models.preprocessor import PreProcessor
+from doctr.utils.gpu import select_gpu_device
 
 from ._utils import remap_preds, split_crops
 
@@ -31,20 +32,19 @@ class RecognitionPredictor(nn.Module):
         model: nn.Module,
         split_wide_crops: bool = True,
     ) -> None:
-
         super().__init__()
         self.pre_processor = pre_processor
         self.model = model.eval()
         self.postprocessor = self.model.postprocessor
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-        if os.environ.get("CUDA_VISIBLE_DEVICES", []) == "":
-            self.device = torch.device("cpu")
-        elif len(os.environ.get("CUDA_VISIBLE_DEVICES", [])) > 0:
-            self.device = torch.device("cuda")
-        if "onnx" not in str((type(self.model))) and (self.device == torch.device("cuda")):
+
+        detected_device, selected_device = select_gpu_device()
+        if "onnx" in str((type(self.model))):
+            selected_device = 'cpu'
             # self.model = nn.DataParallel(self.model)
-            self.model = self.model.to(self.device)
             # self.model = self.model.half()
+        self.device = torch.device(selected_device)
+        self.model = self.model.to(self.device)
+
         self.split_wide_crops = split_wide_crops
         self.critical_ar = 8  # Critical aspect ratio
         self.dil_factor = 1.4  # Dilation factor to overlap the crops
@@ -56,7 +56,6 @@ class RecognitionPredictor(nn.Module):
         crops: Sequence[Union[np.ndarray, torch.Tensor]],
         **kwargs: Any,
     ) -> List[Tuple[str, float]]:
-
         if len(crops) == 0:
             return []
         # Dimension check

--- a/doctr/utils/gpu.py
+++ b/doctr/utils/gpu.py
@@ -27,8 +27,11 @@ def select_gpu_device() -> Tuple[str, str]:
             if os.environ.get("CUDA_VISIBLE_DEVICES") == "":
                 selected_gpu_device = 'cpu'
         case 'mps':
-            # FIXME make arm mps acceleration work
-            # selected_gpu_device=mps
+            # FIXME detected mps selects cpu here because of the many bugs present in the mps implementation of
+            #   torch'es 1.13 LSTM.  As of 5/29/2023, they appear to be actively fixing them.  I did try with torch
+            #   2.0.1 and while the bugs look different it's still broken.  Revisit when later versions of torch
+            #   are available.
+            # pass
             selected_gpu_device = 'cpu'
         case 'cpu':
             pass

--- a/doctr/utils/gpu.py
+++ b/doctr/utils/gpu.py
@@ -1,0 +1,37 @@
+import logging
+import os
+from typing import Tuple
+import torch
+
+log = logging.getLogger(__name__)
+
+
+def select_gpu_device() -> Tuple[str, str]:
+    """tries to find either cuda or arm mps gpu accelerator and choses the most appropriate one,
+    honoring the environment variables (CUDA_VISIBLE_DEVICES), if any have been set.
+
+    returns tuple(best_detected_device, selected_device)
+    best_detected_device reflects capabilities of the system
+    selected_device is the device that should be used (might be cpu even if best_detected_device is eg cuda)
+    """
+    if torch.cuda.is_available():
+        detected_gpu_device = 'cuda'
+    elif torch.backends.mps.is_available() and torch.backends.mps.is_built():
+        detected_gpu_device = 'mps'
+    else:
+        detected_gpu_device = 'cpu'
+
+    selected_gpu_device = detected_gpu_device
+    match detected_gpu_device:  # various exceptions to the above
+        case 'cuda':
+            if os.environ.get("CUDA_VISIBLE_DEVICES") == "":
+                selected_gpu_device = 'cpu'
+        case 'mps':
+            # FIXME make arm mps acceleration work
+            # selected_gpu_device=mps
+            selected_gpu_device = 'cpu'
+        case 'cpu':
+            pass
+
+    log.info(f"{detected_gpu_device=} {selected_gpu_device=}")
+    return detected_gpu_device, selected_gpu_device


### PR DESCRIPTION
* Puts the detection and selection of GPU availablebility into one place.
* adds support for arm mps in addition to the existing cpu and cuda hardware.

Currently, if mps is detected, cpu is selected because I get garbage with the same model when switching to mps.  I still need to debug that.  But at least it doesn't error out on an arm mac.


I also accidentally made this PR into the mindee public fork.  I promptly closed the PR, but ALL our modifications are now in a public PR.  I am not sure if it has any consequences for us.